### PR TITLE
Gameplay: Adjust particle settings

### DIFF
--- a/Assets/Prefabs/Gameplay/TapParticle.prefab
+++ b/Assets/Prefabs/Gameplay/TapParticle.prefab
@@ -116,7 +116,7 @@ ParticleSystem:
     startLifetime:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 10
+      scalar: 13
       minScalar: 5
       maxCurve:
         serializedVersion: 2
@@ -285,7 +285,7 @@ ParticleSystem:
     startSize:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 50
+      scalar: 65
       minScalar: 1
       maxCurve:
         serializedVersion: 2
@@ -4790,7 +4790,7 @@ ParticleSystemRenderer:
   m_SortingLayer: 6
   m_SortingOrder: 0
   m_RenderMode: 0
-  m_SortMode: 0
+  m_SortMode: 3
   m_MinParticleSize: 0
   m_MaxParticleSize: 0.5
   m_CameraVelocityScale: 0

--- a/Assets/Prefabs/Gameplay/TextParticle.prefab
+++ b/Assets/Prefabs/Gameplay/TextParticle.prefab
@@ -52,7 +52,7 @@ ParticleSystem:
   playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
-  useRigidbodyForVelocity: 1
+  useRigidbodyForVelocity: 0
   startDelay:
     serializedVersion: 2
     minMaxState: 0
@@ -116,7 +116,7 @@ ParticleSystem:
     startLifetime:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 1
+      scalar: 0.5
       minScalar: 5
       maxCurve:
         serializedVersion: 2
@@ -660,13 +660,13 @@ ParticleSystem:
   ShapeModule:
     serializedVersion: 6
     enabled: 1
-    type: 4
+    type: 12
     angle: 0
     length: 5
     boxThickness: {x: 0, y: 0, z: 0}
     radiusThickness: 0
     donutRadius: 0.2
-    m_Position: {x: 0, y: 0, z: 0}
+    m_Position: {x: 0, y: 10, z: 0}
     m_Rotation: {x: -90, y: 0, z: 0}
     m_Scale: {x: 1, y: 1, z: 1}
     placementMode: 0
@@ -1600,7 +1600,7 @@ ParticleSystem:
     y:
       serializedVersion: 2
       minMaxState: 1
-      scalar: 30
+      scalar: 60
       minScalar: 0
       maxCurve:
         serializedVersion: 2
@@ -1608,21 +1608,21 @@ ParticleSystem:
         - serializedVersion: 3
           time: 0
           value: 1
-          inSlope: -5.751353
-          outSlope: -5.751353
-          tangentMode: 0
+          inSlope: 0
+          outSlope: -2
+          tangentMode: 69
           weightedMode: 0
           inWeight: 0
-          outWeight: 0.44754702
+          outWeight: 0.16239317
         - serializedVersion: 3
-          time: 0.055218153
-          value: 0.7179775
-          inSlope: -3.2786536
-          outSlope: -3.2786536
-          tangentMode: 0
+          time: 0.5
+          value: 0
+          inSlope: -2
+          outSlope: Infinity
+          tangentMode: 101
           weightedMode: 0
-          inWeight: 0.75628805
-          outWeight: 0.1172394
+          inWeight: 0.33333334
+          outWeight: 0.33333334
         - serializedVersion: 3
           time: 1
           value: 0
@@ -4799,13 +4799,13 @@ ParticleSystemRenderer:
   m_SortingLayer: 6
   m_SortingOrder: 0
   m_RenderMode: 0
-  m_SortMode: 0
+  m_SortMode: 3
   m_MinParticleSize: 0.075
   m_MaxParticleSize: 0.075
   m_CameraVelocityScale: 0
   m_VelocityScale: 0
   m_LengthScale: 1
-  m_SortingFudge: -100
+  m_SortingFudge: 1
   m_NormalDirection: 0
   m_ShadowBias: 0
   m_RenderAlignment: 0

--- a/Assets/Scripts/Gameplay/Particle/ParticleService.cs
+++ b/Assets/Scripts/Gameplay/Particle/ParticleService.cs
@@ -135,7 +135,6 @@ namespace ArcCreate.Gameplay.Particle
             }
 
             Vector2 screenPos = ConvertToScreen(worldPosition);
-            screenPos.y += Values.TextParticleYOffset;
             Particle ps = textParticlePool.Get();
             ps.transform.localPosition = screenPos;
             ps.Stop();

--- a/Assets/Scripts/Gameplay/Utility/Values.cs
+++ b/Assets/Scripts/Gameplay/Utility/Values.cs
@@ -44,7 +44,6 @@ namespace ArcCreate.Gameplay
         public const float ArcMeshOffset = 0.9f;
         public const float TraceAlphaScalar = 0.4779405f;
         public const float ShortTraceAlphaScalar = TraceAlphaScalar * 0.5f;
-        public const float TextParticleYOffset = 60f;
         public const float ArcSegmentLength = 1000f / 14f;
         public const float ArcCapSize = 0.35f;
         public const float ArcCapSizeAdditionMax = 0.5f;


### PR DESCRIPTION
 * ### Changed TapParticle lifetime and their size  
Referencing from official game, their particle is bigger and it stays longer than the current settings in ArcCreate.
This commit try to conform the settings from the official game.
 * ### Make TextParticle have uniform offset from HitParticle  
When in different display ratio, the y position of TextParticle tends to be higher in 4:3.  
This commit mitigates it by moving  TextParticle offset calculation to the ParticleSystem.