### PR TITLE
Scenecontrol: Use camera pixel size instead of screen size

### DIFF
--- a/Assets/Scripts/Gameplay/Scenecontrol/Channels/ContextChannels/ScreenHeightChannel.cs
+++ b/Assets/Scripts/Gameplay/Scenecontrol/Channels/ContextChannels/ScreenHeightChannel.cs
@@ -18,7 +18,8 @@ namespace ArcCreate.Gameplay.Scenecontrol
 
         public override float ValueAt(int timing)
         {
-            return Screen.height;
+            Camera cam = Services.Camera.GameplayCamera;
+            return cam.pixelHeight;
         }
 
         protected override IEnumerable<ValueChannel> GetChildrenChannels()

--- a/Assets/Scripts/Gameplay/Scenecontrol/Channels/ContextChannels/ScreenWidthChannel.cs
+++ b/Assets/Scripts/Gameplay/Scenecontrol/Channels/ContextChannels/ScreenWidthChannel.cs
@@ -18,7 +18,8 @@ namespace ArcCreate.Gameplay.Scenecontrol
 
         public override float ValueAt(int timing)
         {
-            return Screen.width;
+            Camera cam = Services.Camera.GameplayCamera;
+            return cam.pixelWidth;
         }
 
         protected override IEnumerable<ValueChannel> GetChildrenChannels()


### PR DESCRIPTION
Found out ScreenWidth and ScreenHeight context channels are using (editor) screen size and not camera texture size when I'm trying to adapt elements in scenecontrol. 
`Screen` would work on gameplay client but on editor its behavior is not desired, this commit fixes it.