### PR TITLE
Selection : Fix a memory leak on the Result Screen.

### DIFF
--- a/Assets/Scripts/Selection/Interface/ResultScreen.cs
+++ b/Assets/Scripts/Selection/Interface/ResultScreen.cs
@@ -176,6 +176,10 @@ namespace ArcCreate.Selection.Interface
 
         public override void OnUnloadScene()
         {
+            // Destroy Sprite on Scene unload to prevent a memory leak.
+            Destroy(characterImage.sprite.texture);
+            Destroy(characterImage.sprite);
+            
             returnButton.onClick.RemoveListener(ReturnToPreviousScene);
             retryButton.onClick.RemoveListener(RetryChart);
             cts.Cancel();


### PR DESCRIPTION
- Fixed a memory leak caused by not destroying the character sprite on scene exit.

This change should prevent the mysterious memory leak crash that was recently brought up in #devtalk on discord.
I'm not very familiar with code structure/style details, so I've just stuck the `Destroy()` calls right in `OnUnloadScene()` instead of giving them their own method.