### PR TITLE
arcparticle & arccap fadeout

### DIFF
--- a/Assets/Prefabs/Gameplay/ArcNoteParticle.prefab
+++ b/Assets/Prefabs/Gameplay/ArcNoteParticle.prefab
@@ -47,11 +47,11 @@ ParticleSystem:
   simulationSpeed: 10
   stopAction: 0
   cullingMode: 1
-  ringBufferMode: 2
+  ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
   emitterVelocityMode: 0
   looping: 1
-  prewarm: 0
+  prewarm: 1
   playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
@@ -603,7 +603,7 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     randomizeRotationDirection: 0
-    maxNumParticles: 1
+    maxNumParticles: 3
     customEmitterVelocity: {x: 0, y: 0, z: 0}
     size3D: 1
     rotation3D: 0
@@ -4189,18 +4189,18 @@ ParticleSystem:
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
   CustomDataModule:
-    enabled: 0
-    mode0: 0
+    enabled: 1
+    mode0: 2
     vectorComponentCount0: 4
     color0:
       serializedVersion: 2
-      minMaxState: 0
+      minMaxState: 3
       minColor: {r: 1, g: 1, b: 1, a: 1}
       maxColor: {r: 1, g: 1, b: 1, a: 1}
       maxGradient:
         serializedVersion: 2
-        key0: {r: 1, g: 1, b: 1, a: 1}
-        key1: {r: 1, g: 1, b: 1, a: 1}
+        key0: {r: 0.34576362, g: 0.46790293, b: 0.6603774, a: 1}
+        key1: {r: 0.8, g: 0.2, b: 0.4669014, a: 0}
         key2: {r: 0, g: 0, b: 0, a: 0}
         key3: {r: 0, g: 0, b: 0, a: 0}
         key4: {r: 0, g: 0, b: 0, a: 0}
@@ -4208,7 +4208,7 @@ ParticleSystem:
         key6: {r: 0, g: 0, b: 0, a: 0}
         key7: {r: 0, g: 0, b: 0, a: 0}
         ctime0: 0
-        ctime1: 65535
+        ctime1: 65392
         ctime2: 0
         ctime3: 0
         ctime4: 0
@@ -4228,8 +4228,8 @@ ParticleSystem:
         m_NumAlphaKeys: 2
       minGradient:
         serializedVersion: 2
-        key0: {r: 1, g: 1, b: 1, a: 1}
-        key1: {r: 1, g: 1, b: 1, a: 1}
+        key0: {r: 0.8, g: 0.2, b: 0.67570746, a: 1}
+        key1: {r: 0.2509804, g: 0.4157608, b: 0.4509804, a: 0}
         key2: {r: 0, g: 0, b: 0, a: 0}
         key3: {r: 0, g: 0, b: 0, a: 0}
         key4: {r: 0, g: 0, b: 0, a: 0}
@@ -4237,7 +4237,7 @@ ParticleSystem:
         key6: {r: 0, g: 0, b: 0, a: 0}
         key7: {r: 0, g: 0, b: 0, a: 0}
         ctime0: 0
-        ctime1: 65535
+        ctime1: 64891
         ctime2: 0
         ctime3: 0
         ctime4: 0
@@ -4255,7 +4255,7 @@ ParticleSystem:
         m_Mode: 0
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
-    colorLabel0: Color
+    colorLabel0: Fadeout Color
     vector0_0:
       serializedVersion: 2
       minMaxState: 0

--- a/Assets/Prefabs/Gameplay/HoldNoteParticle.prefab
+++ b/Assets/Prefabs/Gameplay/HoldNoteParticle.prefab
@@ -27,6 +27,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 75, y: 75, z: 75}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8180300286406156438}
   m_RootOrder: 0
@@ -42,10 +43,12 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -110,6 +113,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 320, y: 90, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3569648718598980802}
   m_Father: {fileID: 0}
@@ -122,19 +126,19 @@ ParticleSystem:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8182895525809098792}
-  serializedVersion: 6
+  serializedVersion: 8
   lengthInSec: 0.05
   simulationSpeed: 10
   stopAction: 0
   cullingMode: 1
-  ringBufferMode: 2
+  ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
+  emitterVelocityMode: 0
   looping: 1
-  prewarm: 0
+  prewarm: 1
   playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
-  useRigidbodyForVelocity: 1
   startDelay:
     serializedVersion: 2
     minMaxState: 0
@@ -683,7 +687,8 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     randomizeRotationDirection: 0
-    maxNumParticles: 3
+    maxNumParticles: 5
+    customEmitterVelocity: {x: 0, y: 0, z: 0}
     size3D: 1
     rotation3D: 0
     gravityModifier:
@@ -948,7 +953,7 @@ ParticleSystem:
     rateOverTime:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 5
+      scalar: 10
       minScalar: 10
       maxCurve:
         serializedVersion: 2
@@ -2208,6 +2213,62 @@ ParticleSystem:
         m_PreInfinity: 2
         m_PostInfinity: 2
         m_RotationOrder: 4
+  LifetimeByEmitterSpeedModule:
+    enabled: 0
+    m_Curve:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: -0.8
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0.2
+          inSlope: -0.8
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_Range: {x: 0, y: 1}
   ForceModule:
     enabled: 0
     x:
@@ -3638,19 +3699,20 @@ ParticleSystem:
     range: {x: 0, y: 1}
   CollisionModule:
     enabled: 0
-    serializedVersion: 3
+    serializedVersion: 4
     type: 0
     collisionMode: 0
     colliderForce: 0
     multiplyColliderForceByParticleSize: 0
     multiplyColliderForceByParticleSpeed: 0
     multiplyColliderForceByCollisionAngle: 1
-    plane0: {fileID: 0}
-    plane1: {fileID: 0}
-    plane2: {fileID: 0}
-    plane3: {fileID: 0}
-    plane4: {fileID: 0}
-    plane5: {fileID: 0}
+    m_Planes:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     m_Dampen:
       serializedVersion: 2
       minMaxState: 0
@@ -3824,17 +3886,20 @@ ParticleSystem:
     interiorCollisions: 0
   TriggerModule:
     enabled: 0
-    collisionShape0: {fileID: 0}
-    collisionShape1: {fileID: 0}
-    collisionShape2: {fileID: 0}
-    collisionShape3: {fileID: 0}
-    collisionShape4: {fileID: 0}
-    collisionShape5: {fileID: 0}
+    serializedVersion: 2
     inside: 1
     outside: 0
     enter: 0
     exit: 0
+    colliderQueryMode: 0
     radiusScale: 1
+    primitives:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
   SubModule:
     serializedVersion: 2
     enabled: 0
@@ -4208,18 +4273,18 @@ ParticleSystem:
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
   CustomDataModule:
-    enabled: 0
-    mode0: 0
+    enabled: 1
+    mode0: 2
     vectorComponentCount0: 4
     color0:
       serializedVersion: 2
-      minMaxState: 0
+      minMaxState: 3
       minColor: {r: 1, g: 1, b: 1, a: 1}
       maxColor: {r: 1, g: 1, b: 1, a: 1}
       maxGradient:
         serializedVersion: 2
-        key0: {r: 1, g: 1, b: 1, a: 1}
-        key1: {r: 1, g: 1, b: 1, a: 1}
+        key0: {r: 0.5187635, g: 0.28034887, b: 0.7924528, a: 1}
+        key1: {r: 0.14684941, g: 0.34798366, b: 0.41509432, a: 0}
         key2: {r: 0, g: 0, b: 0, a: 0}
         key3: {r: 0, g: 0, b: 0, a: 0}
         key4: {r: 0, g: 0, b: 0, a: 0}
@@ -4227,7 +4292,7 @@ ParticleSystem:
         key6: {r: 0, g: 0, b: 0, a: 0}
         key7: {r: 0, g: 0, b: 0, a: 0}
         ctime0: 0
-        ctime1: 65535
+        ctime1: 65392
         ctime2: 0
         ctime3: 0
         ctime4: 0
@@ -4247,8 +4312,8 @@ ParticleSystem:
         m_NumAlphaKeys: 2
       minGradient:
         serializedVersion: 2
-        key0: {r: 1, g: 1, b: 1, a: 1}
-        key1: {r: 1, g: 1, b: 1, a: 1}
+        key0: {r: 0.31240404, g: 0.110137075, b: 0.5188679, a: 0.49803922}
+        key1: {r: 0.047080822, g: 0.36568922, b: 0.4339623, a: 0}
         key2: {r: 0, g: 0, b: 0, a: 0}
         key3: {r: 0, g: 0, b: 0, a: 0}
         key4: {r: 0, g: 0, b: 0, a: 0}
@@ -4785,10 +4850,12 @@ ParticleSystemRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -4814,6 +4881,7 @@ ParticleSystemRenderer:
   m_SortingLayer: 5
   m_SortingOrder: 0
   m_RenderMode: 0
+  m_MeshDistribution: 0
   m_SortMode: 0
   m_MinParticleSize: 0.25
   m_MaxParticleSize: 0.32
@@ -4830,11 +4898,17 @@ ParticleSystemRenderer:
   m_EnableGPUInstancing: 1
   m_ApplyActiveColorSpace: 1
   m_AllowRoll: 1
+  m_FreeformStretching: 0
+  m_RotateWithStretchDirection: 1
   m_VertexStreams: 00010304
   m_Mesh: {fileID: 0}
   m_Mesh1: {fileID: 0}
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}
+  m_MeshWeighting: 1
+  m_MeshWeighting1: 1
+  m_MeshWeighting2: 1
+  m_MeshWeighting3: 1
   m_MaskInteraction: 0
 --- !u!114 &3977448881185635455
 MonoBehaviour:

--- a/Assets/Scripts/Gameplay/Data/Events/Arc.Rendering.cs
+++ b/Assets/Scripts/Gameplay/Data/Events/Arc.Rendering.cs
@@ -567,6 +567,28 @@ namespace ArcCreate.Gameplay.Data
                 }
             }
 
+            // fadeout arccap if end of arc chain on non 0ms arcs
+            bool isArcCapFadeoutWindow = currentTiming > EndTiming && currentTiming < EndTiming + Values.ArcCapFadeOutTime;
+            if (NextArc == null && Timing + 1 < EndTiming && isArcCapFadeoutWindow)
+            {
+                if (!isControllerMode)
+                {
+                    float distance = Mathf.Clamp(1 - ((currentTiming - EndTiming) / Values.ArcCapFadeOutTime), 0, 1);
+
+                    Vector3 startPos = new Vector3(WorldXAt(Timing), WorldYAt(Timing));
+                    Vector3 endPos = new Vector3(WorldXAt(EndTiming), WorldYAt(EndTiming));
+                    Vector3 capPos = endPos - startPos - (fallDirection * z); // helép what am i doing
+                    Vector3 scale = new Vector3(ArcCapSize, ArcCapSize, 1);
+                    Vector4 color = new Color(1, 1, 1, distance * (IsTrace ? Values.TraceCapAlpha : Values.ArcCapAlpha));
+
+                    return (true, Matrix4x4.TRS(capPos, Quaternion.identity, scale), color);
+                }
+                else
+                {
+                    return (false, default, default);
+                }
+            }
+
             return (false, default, default);
         }
 

--- a/Assets/Scripts/Gameplay/Particle/Particle.cs
+++ b/Assets/Scripts/Gameplay/Particle/Particle.cs
@@ -6,11 +6,11 @@ namespace ArcCreate.Gameplay.Particle
     public class Particle : MonoBehaviour
     {
         [SerializeField] private SpriteRenderer sprite;
-
         private ParticleSystem ps;
         private ParticleSystemRenderer render;
         private Transform cachedTransform;
-
+        
+        public ParticleSystem ParticleSystem => ps;
         public Transform Transform => cachedTransform;
 
         public void Play()

--- a/Assets/Scripts/Gameplay/Particle/ParticleSchedule.cs
+++ b/Assets/Scripts/Gameplay/Particle/ParticleSchedule.cs
@@ -1,8 +1,15 @@
 namespace ArcCreate.Gameplay.Particle
 {
-    public struct ParticleSchedule
+    public class ParticleSchedule
     {
-        public Particle Particle;
-        public float ExpireAt;
+        public readonly Particle Particle;
+        public readonly float ExpireAt;
+        public bool IsExpired = false;
+
+        public ParticleSchedule(Particle _particle, float _expireAt)
+        {
+            Particle = _particle;
+            ExpireAt = _expireAt;
+        }
     }
 }

--- a/Assets/Scripts/Gameplay/Particle/ParticleService.cs
+++ b/Assets/Scripts/Gameplay/Particle/ParticleService.cs
@@ -78,6 +78,8 @@ namespace ArcCreate.Gameplay.Particle
         private Material GoodMaterial { get; set; }
 
         private Material MissMaterial { get; set; }
+        private ParticleSystem.ColorOverLifetimeModule arcNoteParticlePrefabColorOverLifetime;
+        private ParticleSystem.MinMaxGradient arcNoteParticleFadeoutColor;
 
         public void UpdateParticles()
         {
@@ -102,7 +104,22 @@ namespace ArcCreate.Gameplay.Particle
             {
                 LongNote reference = pair.Key;
                 ParticleSchedule schedule = pair.Value;
-                if (currentRealTime >= schedule.ExpireAt)
+                ParticleSystem ps = schedule.Particle.ParticleSystem;
+
+                if (!schedule.IsExpired && currentRealTime >= schedule.ExpireAt)
+                {
+                    ps.Stop();
+                    ps.Clear();
+                    ps.Emit(ps.main.maxParticles);
+
+                    var colorModule = ps.colorOverLifetime;
+                    colorModule.enabled = true;
+                    colorModule.color = arcNoteParticleFadeoutColor;
+
+                    schedule.IsExpired = true;
+                }
+
+                if (schedule.IsExpired && !ps.IsAlive())
                 {
                     schedule.Particle.Stop();
                     arcParticlePool.Return(schedule.Particle);
@@ -121,7 +138,16 @@ namespace ArcCreate.Gameplay.Particle
             {
                 LongNote reference = pair.Key;
                 ParticleSchedule schedule = pair.Value;
-                if (currentRealTime >= schedule.ExpireAt)
+                ParticleSystem ps = schedule.Particle.ParticleSystem;
+
+                if (!schedule.IsExpired && currentRealTime >= schedule.ExpireAt)
+                {
+                    ps.Stop();
+
+                    schedule.IsExpired = true;
+                }
+
+                if (schedule.IsExpired && !ps.IsAlive())
                 {
                     schedule.Particle.Stop();
                     holdParticlePool.Return(schedule.Particle);
@@ -226,21 +252,17 @@ namespace ArcCreate.Gameplay.Particle
 
                 playingHoldParticles.Add(
                     reference,
-                    new ParticleSchedule()
-                    {
-                        ExpireAt = currentRealTime + longParticlePersistDuration,
-                        Particle = ps,
-                    });
+                    new ParticleSchedule(ps, currentRealTime + longParticlePersistDuration)
+                );
             }
             else
             {
                 ParticleSchedule ps = playingHoldParticles[reference];
+
                 ps.Particle.transform.localPosition = screenPos;
-                playingHoldParticles[reference] = new ParticleSchedule()
-                {
-                    ExpireAt = currentRealTime + longParticlePersistDuration,
-                    Particle = ps.Particle,
-                };
+                ps.Particle.Play();
+
+                playingHoldParticles[reference] = new ParticleSchedule(ps.Particle, currentRealTime + longParticlePersistDuration);
             }
         }
 
@@ -253,28 +275,33 @@ namespace ArcCreate.Gameplay.Particle
             if (!playingArcParticles.ContainsKey(reference))
             {
                 Particle ps = arcParticlePool.Get();
+                ParticleSystem psys = ps.ParticleSystem;
+
+                var colorModule = psys.colorOverLifetime;
+                colorModule.color = arcNoteParticlePrefabColorOverLifetime.color;
+
                 ps.ApplyColor(color1, color2);
                 ps.transform.localPosition = screenPos;
                 ps.Play();
 
                 playingArcParticles.Add(
                     reference,
-                    new ParticleSchedule()
-                    {
-                        ExpireAt = currentRealTime + longParticlePersistDuration,
-                        Particle = ps,
-                    });
+                    new ParticleSchedule(ps, currentRealTime + longParticlePersistDuration)
+                );
             }
             else
             {
                 ParticleSchedule ps = playingArcParticles[reference];
+                ParticleSystem psys = ps.Particle.ParticleSystem;
+
+                var colorModule = psys.colorOverLifetime;
+                colorModule.color = arcNoteParticlePrefabColorOverLifetime.color;
+
                 ps.Particle.ApplyColor(color1, color2);
                 ps.Particle.transform.localPosition = screenPos;
-                playingArcParticles[reference] = new ParticleSchedule()
-                {
-                    ExpireAt = currentRealTime + longParticlePersistDuration,
-                    Particle = ps.Particle,
-                };
+                ps.Particle.Play();
+
+                playingArcParticles[reference] = new ParticleSchedule(ps.Particle, currentRealTime + longParticlePersistDuration);
             }
         }
 
@@ -331,6 +358,10 @@ namespace ArcCreate.Gameplay.Particle
             arcNoteParticlePrefab = Instantiate(arcNoteParticlePrefab, transform);
             holdNoteParticlePrefab = Instantiate(holdNoteParticlePrefab, transform);
 
+            var psys = arcNoteParticlePrefab.GetComponent<ParticleSystem>();
+            arcNoteParticlePrefabColorOverLifetime = psys.colorOverLifetime;
+            arcNoteParticleFadeoutColor = psys.customData.GetColor(ParticleSystemCustomData.Custom1);
+            
             arcParticlePool = Pools.New<Particle>(
                 Values.ArcParticlePoolName,
                 arcNoteParticlePrefab,

--- a/Assets/Scripts/Gameplay/Utility/Values.cs
+++ b/Assets/Scripts/Gameplay/Utility/Values.cs
@@ -47,6 +47,7 @@ namespace ArcCreate.Gameplay
         public const float ArcSegmentLength = 1000f / 14f;
         public const float ArcCapSize = 0.35f;
         public const float ArcCapSizeAdditionMax = 0.5f;
+        public const float ArcCapFadeOutTime = 130;
         public const float TraceCapSize = 0.21f;
         public const float ArcCapAlpha = 1f;
         public const float TraceCapAlpha = 0.5f;


### PR DESCRIPTION
commits & commit messages are kinda fucked sorry about that

- arcs: emit an extra batch of particles that fade out so they dont disappear abruptly
- arccaps: take an extra 130ms to fade out at the end of arcs/traces (not much of an idea what i was doing with the position stuff honestly, that might be broken but seemed fine to me from testing); 0-1ms arcs get no arccap fadeout
- holds: this is more for consistency reasons than anything, but hold particles also die out before being added back to the pool