### PR TITLE
Gameplay: Fix glitching arcs of different colors (2)

### DIFF
--- a/Assets/Scripts/Gameplay/Data/Events/Arc.Rendering.cs
+++ b/Assets/Scripts/Gameplay/Data/Events/Arc.Rendering.cs
@@ -250,7 +250,20 @@ namespace ArcCreate.Gameplay.Data
                 }
                 else
                 {
-                    Services.Render.DrawArcSegment(Color, highlight, matrix * bodyMatrix, color, IsSelected, redArcValue, basePos.y + segment.EndPosition.y, depth);
+                    Services.Render.DrawArcSegment(Color,
+                        highlight,
+                        matrix * bodyMatrix,
+                        color,
+                        IsSelected,
+                        redArcValue,
+                        basePos.y + segment.EndPosition.y,
+                        depth,
+                        new Vector2(XStart,
+                            YStart),
+                        new Vector2(XEnd,
+                            YEnd),
+                        new Vector2Int(Timing,
+                            EndTiming));
                     if (!groupProperties.NoShadow)
                     {
                         Services.Render.DrawArcShadow(matrix * shadowMatrix, color, cornerOffset);

--- a/Assets/Scripts/Gameplay/Render/IRenderService.cs
+++ b/Assets/Scripts/Gameplay/Render/IRenderService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace ArcCreate.Gameplay.Render
@@ -17,7 +16,17 @@ namespace ArcCreate.Gameplay.Render
 
         void DrawArcHead(int colorId, bool highlight, Matrix4x4 matrix, Color color, bool selected, float redValue, float y);
 
-        void DrawArcSegment(int colorId, bool highlight, Matrix4x4 matrix, Color color, bool selected, float redValue, float y, float depth);
+        void DrawArcSegment(int colorId,
+            bool highlight,
+            Matrix4x4 matrix,
+            Color color,
+            bool selected,
+            float redValue,
+            float y,
+            float depth,
+            Vector2 arcStartPos,
+            Vector2 arcEndPos,
+            Vector2Int timingStartEnd);
 
         void DrawArcShadow(Matrix4x4 matrix, Color color, Vector4 cornerOffset);
 

--- a/Assets/Scripts/Gameplay/Render/Properties/ArcDrawCall.cs
+++ b/Assets/Scripts/Gameplay/Render/Properties/ArcDrawCall.cs
@@ -7,6 +7,7 @@ namespace ArcCreate.Gameplay.Render
         public Matrix4x4 Matrix;
         public Vector4 Color;
         public Vector4 Properties;
+        public int ColorId;
         public float Depth;
     }
 }

--- a/Assets/Scripts/Gameplay/Render/Properties/ArcDrawCall.cs
+++ b/Assets/Scripts/Gameplay/Render/Properties/ArcDrawCall.cs
@@ -9,5 +9,8 @@ namespace ArcCreate.Gameplay.Render
         public Vector4 Properties;
         public int ColorId;
         public float Depth;
+        public Vector2 ArcStartPos;
+        public Vector2 ArcEndPos;
+        public Vector2Int TimingStartEnd;
     }
 }

--- a/Assets/Scripts/Gameplay/Render/Properties/ArcDrawCallComparer.cs
+++ b/Assets/Scripts/Gameplay/Render/Properties/ArcDrawCallComparer.cs
@@ -1,12 +1,50 @@
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace ArcCreate.Gameplay.Render
 {
     public class ArcDrawCallComparer : IComparer<ArcDrawCall>
     {
-        public int Compare(ArcDrawCall x, ArcDrawCall y)
+        private static int ChainCompare(params int[] compares)
         {
-            return -x.Depth.CompareTo(y.Depth);
+            foreach (int cmp in compares)
+            {
+                if (cmp != 0) return cmp;
+            }
+
+            return compares[^1];
         }
+
+        private static int ByColorId(ArcDrawCall a, ArcDrawCall b) =>
+            a.ColorId.CompareTo(b.ColorId);
+
+        private static int ByDepth(ArcDrawCall a, ArcDrawCall b) =>
+            a.Depth.CompareTo(b.Depth);
+
+        private static int ByYPos(ArcDrawCall a, ArcDrawCall b, bool byEnd = false) =>
+            byEnd
+                ? a.ArcEndPos.y.CompareTo(b.ArcEndPos.y)
+                : a.ArcStartPos.y.CompareTo(b.ArcStartPos.y);
+
+        private static int ByXPosAbs(ArcDrawCall a, ArcDrawCall b, bool byEnd = false) =>
+            byEnd
+                ? Mathf.Abs(a.ArcEndPos.x - .5f).CompareTo(Mathf.Abs(b.ArcEndPos.x - .5f))
+                : Mathf.Abs(a.ArcStartPos.x - .5f).CompareTo(Mathf.Abs(b.ArcStartPos.x - .5f));
+
+        private static int ByArcTiming(ArcDrawCall a, ArcDrawCall b, bool byEnd = false) =>
+            byEnd
+                ? a.TimingStartEnd.y.CompareTo(b.TimingStartEnd.y)
+                : a.TimingStartEnd.x.CompareTo(b.TimingStartEnd.x);
+
+        public int Compare(ArcDrawCall a, ArcDrawCall b) =>
+            ChainCompare(
+                ByYPos(a, b),
+                ByYPos(a, b, true),
+                ByColorId(a, b),
+                -ByXPosAbs(a,b),
+                -ByXPosAbs(a,b, true),
+                -ByArcTiming(a, b),
+                -ByArcTiming(a, b, true)
+            );
     }
 }

--- a/Assets/Scripts/Gameplay/Render/Properties/ArcDrawCallComparer.cs
+++ b/Assets/Scripts/Gameplay/Render/Properties/ArcDrawCallComparer.cs
@@ -1,19 +1,25 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace ArcCreate.Gameplay.Render
 {
     public class ArcDrawCallComparer : IComparer<ArcDrawCall>
     {
-        private static int ChainCompare(params int[] compares)
+#if UNITY_EDITOR
+        private static int ChainCompareDebug(ArcDrawCall a, ArcDrawCall b, params int[] compares)
         {
-            foreach (int cmp in compares)
+            foreach (int compare in compares)
             {
-                if (cmp != 0) return cmp;
+                if (compare != 0) return compare;
             }
 
-            return compares[^1];
+            if (a.ColorId != b.ColorId) Debug.LogWarning("Cannot distinguish");
+            return 0;
         }
+#endif
+
+        private static int ChainCompare(params int[] compares) => compares.FirstOrDefault(x => x != 0);
 
         private static int ByColorId(ArcDrawCall a, ArcDrawCall b) =>
             a.ColorId.CompareTo(b.ColorId);
@@ -21,30 +27,34 @@ namespace ArcCreate.Gameplay.Render
         private static int ByDepth(ArcDrawCall a, ArcDrawCall b) =>
             a.Depth.CompareTo(b.Depth);
 
-        private static int ByYPos(ArcDrawCall a, ArcDrawCall b, bool byEnd = false) =>
-            byEnd
-                ? a.ArcEndPos.y.CompareTo(b.ArcEndPos.y)
-                : a.ArcStartPos.y.CompareTo(b.ArcStartPos.y);
+        private static int ByYPos(ArcDrawCall a, ArcDrawCall b) =>
+            a.ArcStartPos.y.CompareTo(b.ArcStartPos.y);
 
-        private static int ByXPosAbs(ArcDrawCall a, ArcDrawCall b, bool byEnd = false) =>
-            byEnd
-                ? Mathf.Abs(a.ArcEndPos.x - .5f).CompareTo(Mathf.Abs(b.ArcEndPos.x - .5f))
-                : Mathf.Abs(a.ArcStartPos.x - .5f).CompareTo(Mathf.Abs(b.ArcStartPos.x - .5f));
+        private static int ByYEndPos(ArcDrawCall a, ArcDrawCall b) =>
+            a.ArcEndPos.y.CompareTo(b.ArcEndPos.y);
 
-        private static int ByArcTiming(ArcDrawCall a, ArcDrawCall b, bool byEnd = false) =>
-            byEnd
-                ? a.TimingStartEnd.y.CompareTo(b.TimingStartEnd.y)
-                : a.TimingStartEnd.x.CompareTo(b.TimingStartEnd.x);
+        private static int ByXPosAbs(ArcDrawCall a, ArcDrawCall b) =>
+            Mathf.Abs(a.ArcStartPos.x - .5f).CompareTo(Mathf.Abs(b.ArcStartPos.x - .5f));
+
+        private static int ByXEndPosAbs(ArcDrawCall a, ArcDrawCall b) =>
+            Mathf.Abs(a.ArcEndPos.x - .5f).CompareTo(Mathf.Abs(b.ArcEndPos.x - .5f));
+
+        private static int ByArcTiming(ArcDrawCall a, ArcDrawCall b) =>
+            a.TimingStartEnd.x.CompareTo(b.TimingStartEnd.x);
+
+        private static int ByArcEndTiming(ArcDrawCall a, ArcDrawCall b) =>
+            a.TimingStartEnd.y.CompareTo(b.TimingStartEnd.y);
 
         public int Compare(ArcDrawCall a, ArcDrawCall b) =>
             ChainCompare(
                 ByYPos(a, b),
-                ByYPos(a, b, true),
+                ByYEndPos(a, b),
                 ByColorId(a, b),
-                -ByXPosAbs(a,b),
-                -ByXPosAbs(a,b, true),
+                -ByXPosAbs(a, b),
+                -ByXEndPosAbs(a, b),
                 -ByArcTiming(a, b),
-                -ByArcTiming(a, b, true)
+                -ByArcEndTiming(a, b),
+                -ByDepth(a, b)
             );
     }
 }

--- a/Assets/Scripts/Gameplay/Render/RenderService.cs
+++ b/Assets/Scripts/Gameplay/Render/RenderService.cs
@@ -40,7 +40,7 @@ namespace ArcCreate.Gameplay.Render
         private readonly List<ArcDrawCall> queuedArcDrawCalls = new List<ArcDrawCall>();
         private readonly List<ArcDrawCall> queuedTraceDrawCalls = new List<ArcDrawCall>();
         private readonly IComparer<ArcDrawCall> arcDrawCallComparer = new ArcDrawCallComparer();
-        private readonly Dictionary<int, InstancedRendererPool> arcSegmentDrawers = new();
+        private InstancedRendererPool arcSegmentDrawer;
         private InstancedRendererPool arcHeadDrawer;
         private readonly Dictionary<Texture, InstancedRendererPool> arcCapDrawers = new Dictionary<Texture, InstancedRendererPool>();
         private InstancedRendererPool arcShadowDrawer;
@@ -48,22 +48,6 @@ namespace ArcCreate.Gameplay.Render
         private InstancedRendererPool traceHeadDrawer;
         private InstancedRendererPool traceShadowDrawer;
         private InstancedRendererPool heightIndicatorDrawer;
-        
-        private Material arcMaterialPrototype;
-        private readonly Dictionary<int, Material> arcMaterialCache = new();
-
-        private Material GetArcMaterialForColor(int colorId)
-        {
-            if (arcMaterialCache.TryGetValue(colorId, out var mat))
-            {
-                return mat;
-            }
-
-            var newMat = Instantiate(arcMaterialPrototype);
-            newMat.renderQueue += colorId;
-            arcMaterialCache[colorId] = newMat;
-            return newMat;
-        }
 
         // Arctap
         private readonly Dictionary<Texture, InstancedRendererPool> arctapDrawers = new Dictionary<Texture, InstancedRendererPool>();
@@ -115,7 +99,17 @@ namespace ArcCreate.Gameplay.Render
             connectionLineDrawer.RegisterInstance(matrix, color);
         }
 
-        public void DrawArcSegment(int colorId, bool highlight, Matrix4x4 matrix, Color color, bool selected, float redValue, float y, float depth)
+        public void DrawArcSegment(int colorId,
+            bool highlight,
+            Matrix4x4 matrix,
+            Color color,
+            bool selected,
+            float redValue,
+            float y,
+            float depth,
+            Vector2 arcStartPos,
+            Vector2 arcEndPos,
+            Vector2Int timingStartEnd)
         {
             (Color high, Color low) = Services.Skin.GetArcColor(colorId);
             color *= Color.Lerp(Color.Lerp(low, high, (y - 1) / 4.5f), Color.red, redValue);
@@ -127,6 +121,9 @@ namespace ArcCreate.Gameplay.Render
                 Properties = properties,
                 ColorId = colorId,
                 Depth = depth,
+                ArcStartPos = arcStartPos,
+                ArcEndPos = arcEndPos,
+                TimingStartEnd = timingStartEnd,
             });
         }
 
@@ -206,8 +203,6 @@ namespace ArcCreate.Gameplay.Render
         {
             arctapShadowDrawer.RegisterInstance(matrix, color);
         }
-        
-        private readonly HashSet<int> drawnColorIds = new();
 
         public void UpdateRenderers()
         {
@@ -252,29 +247,15 @@ namespace ArcCreate.Gameplay.Render
             }
 
             queuedArcDrawCalls.Sort(arcDrawCallComparer);
-            drawnColorIds.Clear();
             foreach (var call in queuedArcDrawCalls)
             {
-                if (arcSegmentDrawers.TryGetValue(call.ColorId, out var pool))
-                {
-                    pool.RegisterInstance(
-                        call.Matrix,
-                        call.Color,
-                        call.Properties);
-                }
-                else
-                {
-                    RegisterRendererPoolForColor(call.ColorId).RegisterInstance(call.Matrix, call.Color, call.Properties);
-                }
-
-                drawnColorIds.Add(call.ColorId);
+                arcSegmentDrawer.RegisterInstance(
+                    call.Matrix,
+                    call.Color,
+                    call.Properties);
             }
 
-            foreach (int colorId in drawnColorIds)
-            {
-                arcSegmentDrawers[colorId].Draw(notesCamera, layer);
-            }
-
+            arcSegmentDrawer.Draw(notesCamera, layer);
             queuedArcDrawCalls.Clear();
 
             foreach (var pair in arctapDrawers)
@@ -324,33 +305,21 @@ namespace ArcCreate.Gameplay.Render
             UpdateLoadedState();
         }
 
-        private InstancedRendererPool RegisterRendererPoolForColor(int colorId)
-        {
-            var pool = new InstancedRendererPool(
-                GetArcMaterialForColor(colorId),
-                ArcMeshGenerator.GetSegmentMesh(false),
-                true);
-            arcSegmentDrawers.Add(colorId, pool);
-
-            return pool;
-        }
-        
         public void SetArcMaterial(Material material)
         {
-            foreach (var (_, pool) in arcSegmentDrawers) pool?.Dispose();
-            arcSegmentDrawers.Clear();
+            arcSegmentDrawer?.Dispose();
             arcHeadDrawer?.Dispose();
 
-            arcMaterialPrototype = material;
-            
+            arcSegmentDrawer = new InstancedRendererPool(
+                material,
+                ArcMeshGenerator.GetSegmentMesh(false),
+                true);
+
             arcHeadDrawer = new InstancedRendererPool(
                 material,
                 ArcMeshGenerator.GetHeadMesh(false),
                 true);
 
-            RegisterRendererPoolForColor(0);
-            RegisterRendererPoolForColor(1);
-            
             UpdateLoadedState();
         }
 
@@ -381,7 +350,7 @@ namespace ArcCreate.Gameplay.Render
         private void UpdateLoadedState()
         {
             IsLoaded = connectionLineDrawer != null
-                    && arcSegmentDrawers != null
+                    && arcSegmentDrawer != null
                     && arcHeadDrawer != null
                     && traceSegmentDrawer != null
                     && traceHeadDrawer != null
@@ -412,9 +381,6 @@ namespace ArcCreate.Gameplay.Render
 
             generatedMaterials.Clear();
 
-            foreach (var (_, mat) in arcMaterialCache) Destroy(mat);
-            arcMaterialCache.Clear();
-            
             foreach (var pair in holdDrawers)
             {
                 pair.Value.Dispose();
@@ -439,8 +405,7 @@ namespace ArcCreate.Gameplay.Render
                 pair.Value.Dispose();
             }
 
-            foreach (var (_, pool) in arcSegmentDrawers) pool?.Dispose();
-            arcSegmentDrawers.Clear();
+            arcSegmentDrawer.Dispose();
 
             foreach (var pair in arctapDrawers)
             {

--- a/Assets/Scripts/Gameplay/Render/RenderService.cs
+++ b/Assets/Scripts/Gameplay/Render/RenderService.cs
@@ -40,7 +40,7 @@ namespace ArcCreate.Gameplay.Render
         private readonly List<ArcDrawCall> queuedArcDrawCalls = new List<ArcDrawCall>();
         private readonly List<ArcDrawCall> queuedTraceDrawCalls = new List<ArcDrawCall>();
         private readonly IComparer<ArcDrawCall> arcDrawCallComparer = new ArcDrawCallComparer();
-        private InstancedRendererPool arcSegmentDrawer;
+        private readonly Dictionary<int, InstancedRendererPool> arcSegmentDrawers = new();
         private InstancedRendererPool arcHeadDrawer;
         private readonly Dictionary<Texture, InstancedRendererPool> arcCapDrawers = new Dictionary<Texture, InstancedRendererPool>();
         private InstancedRendererPool arcShadowDrawer;
@@ -48,6 +48,22 @@ namespace ArcCreate.Gameplay.Render
         private InstancedRendererPool traceHeadDrawer;
         private InstancedRendererPool traceShadowDrawer;
         private InstancedRendererPool heightIndicatorDrawer;
+        
+        private Material arcMaterialPrototype;
+        private readonly Dictionary<int, Material> arcMaterialCache = new();
+
+        private Material GetArcMaterialForColor(int colorId)
+        {
+            if (arcMaterialCache.TryGetValue(colorId, out var mat))
+            {
+                return mat;
+            }
+
+            var newMat = Instantiate(arcMaterialPrototype);
+            newMat.renderQueue += colorId;
+            arcMaterialCache[colorId] = newMat;
+            return newMat;
+        }
 
         // Arctap
         private readonly Dictionary<Texture, InstancedRendererPool> arctapDrawers = new Dictionary<Texture, InstancedRendererPool>();
@@ -109,6 +125,7 @@ namespace ArcCreate.Gameplay.Render
                 Matrix = matrix,
                 Color = color,
                 Properties = properties,
+                ColorId = colorId,
                 Depth = depth,
             });
         }
@@ -189,6 +206,8 @@ namespace ArcCreate.Gameplay.Render
         {
             arctapShadowDrawer.RegisterInstance(matrix, color);
         }
+        
+        private readonly HashSet<int> drawnColorIds = new();
 
         public void UpdateRenderers()
         {
@@ -233,15 +252,29 @@ namespace ArcCreate.Gameplay.Render
             }
 
             queuedArcDrawCalls.Sort(arcDrawCallComparer);
+            drawnColorIds.Clear();
             foreach (var call in queuedArcDrawCalls)
             {
-                arcSegmentDrawer.RegisterInstance(
-                    call.Matrix,
-                    call.Color,
-                    call.Properties);
+                if (arcSegmentDrawers.TryGetValue(call.ColorId, out var pool))
+                {
+                    pool.RegisterInstance(
+                        call.Matrix,
+                        call.Color,
+                        call.Properties);
+                }
+                else
+                {
+                    RegisterRendererPoolForColor(call.ColorId).RegisterInstance(call.Matrix, call.Color, call.Properties);
+                }
+
+                drawnColorIds.Add(call.ColorId);
             }
 
-            arcSegmentDrawer.Draw(notesCamera, layer);
+            foreach (int colorId in drawnColorIds)
+            {
+                arcSegmentDrawers[colorId].Draw(notesCamera, layer);
+            }
+
             queuedArcDrawCalls.Clear();
 
             foreach (var pair in arctapDrawers)
@@ -291,21 +324,33 @@ namespace ArcCreate.Gameplay.Render
             UpdateLoadedState();
         }
 
-        public void SetArcMaterial(Material material)
+        private InstancedRendererPool RegisterRendererPoolForColor(int colorId)
         {
-            arcSegmentDrawer?.Dispose();
-            arcHeadDrawer?.Dispose();
-
-            arcSegmentDrawer = new InstancedRendererPool(
-                material,
+            var pool = new InstancedRendererPool(
+                GetArcMaterialForColor(colorId),
                 ArcMeshGenerator.GetSegmentMesh(false),
                 true);
+            arcSegmentDrawers.Add(colorId, pool);
 
+            return pool;
+        }
+        
+        public void SetArcMaterial(Material material)
+        {
+            foreach (var (_, pool) in arcSegmentDrawers) pool?.Dispose();
+            arcSegmentDrawers.Clear();
+            arcHeadDrawer?.Dispose();
+
+            arcMaterialPrototype = material;
+            
             arcHeadDrawer = new InstancedRendererPool(
                 material,
                 ArcMeshGenerator.GetHeadMesh(false),
                 true);
 
+            RegisterRendererPoolForColor(0);
+            RegisterRendererPoolForColor(1);
+            
             UpdateLoadedState();
         }
 
@@ -336,7 +381,7 @@ namespace ArcCreate.Gameplay.Render
         private void UpdateLoadedState()
         {
             IsLoaded = connectionLineDrawer != null
-                    && arcSegmentDrawer != null
+                    && arcSegmentDrawers != null
                     && arcHeadDrawer != null
                     && traceSegmentDrawer != null
                     && traceHeadDrawer != null
@@ -367,6 +412,9 @@ namespace ArcCreate.Gameplay.Render
 
             generatedMaterials.Clear();
 
+            foreach (var (_, mat) in arcMaterialCache) Destroy(mat);
+            arcMaterialCache.Clear();
+            
             foreach (var pair in holdDrawers)
             {
                 pair.Value.Dispose();
@@ -391,7 +439,8 @@ namespace ArcCreate.Gameplay.Render
                 pair.Value.Dispose();
             }
 
-            arcSegmentDrawer.Dispose();
+            foreach (var (_, pool) in arcSegmentDrawers) pool?.Dispose();
+            arcSegmentDrawers.Clear();
 
             foreach (var pair in arctapDrawers)
             {


### PR DESCRIPTION
> previous (#78)

Fix that arc renderer is sorted by colorId regardless of position:

| <img width="758" height="462" alt="image" src="https://github.com/user-attachments/assets/b546ceef-f8d3-45ee-aff5-a51449ac26c9" /> |
| - |

---

This implementation is still in-consist with the official one, especially when encountering following situation:

| This branch | Official (Arcade) |
| - | - |
| <img width="325" height="260" alt="image" src="https://github.com/user-attachments/assets/45465af4-e730-4b98-b792-fc526827cb30" /> | <img width="368" height="283" alt="image" src="https://github.com/user-attachments/assets/c6eee0d7-4b33-4b65-b3e6-7d89fe93fcaa" /> |

