### PR TITLE
Compose: impl the layout lock

### DIFF
--- a/Assets/Scenes/Compose.unity
+++ b/Assets/Scenes/Compose.unity
@@ -38,7 +38,6 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37312585, g: 0.3807451, b: 0.358728, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -46375,6 +46374,161 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 786058174}
   m_CullTransparentMesh: 0
+--- !u!1001 &788986646
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1216332928}
+    m_Modifications:
+    - target: {fileID: 6258816204915290024, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_Text
+      value: "\uE899"
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816204915290024, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_FontData.m_FontSize
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816204915290026, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_Name
+      value: Icon
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568548, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_Name
+      value: LayoutLock
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 6258816205848568570, guid: b478ebaa3ae36f1fe9dc18ef70e70acc, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: b478ebaa3ae36f1fe9dc18ef70e70acc, type: 3}
+--- !u!114 &788986649
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258816205294475762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &791619729
 GameObject:
   m_ObjectHideFlags: 0
@@ -67095,6 +67249,71 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: Compose.UI.Project.Label.SyncBaseBPM
   readIdFromContent: 0
+--- !u!1 &1216332927
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1216332928}
+  - component: {fileID: 1216332929}
+  m_Layer: 11
+  m_Name: Layout
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1216332928
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1216332927}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5857211231557519157}
+  - {fileID: 6258816205294475763}
+  m_Father: {fileID: 1369165392}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 132.5, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1216332929
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1216332927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 2
+  m_Spacing: 2.5
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &1217571761
 GameObject:
   m_ObjectHideFlags: 0
@@ -74356,7 +74575,7 @@ RectTransform:
   m_Children:
   - {fileID: 3061022598171845188}
   - {fileID: 24354083}
-  - {fileID: 5857211231557519157}
+  - {fileID: 1216332928}
   - {fileID: 235381250}
   - {fileID: 114306322}
   m_Father: {fileID: 1418732314}
@@ -91344,7 +91563,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1931281401}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.8887527
+  m_Size: 0.8887526
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -95603,7 +95822,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 342982843}
   m_HandleRect: {fileID: 342982842}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -106835,7 +107054,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 505154476}
   m_Direction: 2
   m_Value: 0.999999
-  m_Size: 0.920447
+  m_Size: 0.92044705
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -117547,8 +117766,8 @@ RectTransform:
   - {fileID: 5857211231566391408}
   - {fileID: 1739492884}
   - {fileID: 295966849}
-  m_Father: {fileID: 1369165392}
-  m_RootOrder: 2
+  m_Father: {fileID: 1216332928}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -117576,6 +117795,8 @@ MonoBehaviour:
   customLayoutRowPrefab: {fileID: 1955018993492661915, guid: 282767bf838caf14d9efed21271a4a7e,
     type: 3}
   customLayoutRowsParent: {fileID: 1141675709}
+  layoutLockToggle: {fileID: 6258816205294475764}
+  layoutLockIcon: {fileID: 6258816205703468222}
 --- !u!224 &5857211231566391408
 RectTransform:
   m_ObjectHideFlags: 0
@@ -117957,6 +118178,90 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: -5}
   m_SizeDelta: {x: -10, y: -10}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &6258816205294475757 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6258816205848568571, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+    type: 3}
+  m_PrefabInstance: {fileID: 788986646}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258816205294475762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &6258816205294475762 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6258816205848568548, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+    type: 3}
+  m_PrefabInstance: {fileID: 788986646}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &6258816205294475763 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6258816205848568549, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+    type: 3}
+  m_PrefabInstance: {fileID: 788986646}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6258816205294475764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258816205294475762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6258816205294475757}
+  toggleTransition: 0
+  graphic: {fileID: 0}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_IsOn: 1
+--- !u!114 &6258816205703468222 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6258816204915290024, guid: b478ebaa3ae36f1fe9dc18ef70e70acc,
+    type: 3}
+  m_PrefabInstance: {fileID: 788986646}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b616e0308c79a454ebc4f2af9f4e7668, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &6258816206060424512
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Compose/Components/PanelLayoutManager.cs
+++ b/Assets/Scripts/Compose/Components/PanelLayoutManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using DynamicPanels;
+using Google.MaterialDesign.Icons;
 using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.UI;
@@ -11,6 +12,7 @@ namespace ArcCreate.Compose.Components
     public class PanelLayoutManager : MonoBehaviour, IItemNameDialogConsumer
     {
         private const string PlayerPrefKey = "Compose.CustomPanelLayout";
+        private const string PlayerPrefLayoutLockKey = "Compose.PanelLayoutLock";
 
         [SerializeField] private Button togglePickerButton;
         [SerializeField] private GameObject picker;
@@ -20,6 +22,8 @@ namespace ArcCreate.Compose.Components
         [SerializeField] private SaveItemNameDialog saveLayoutDialog;
         [SerializeField] private GameObject customLayoutRowPrefab;
         [SerializeField] private Transform customLayoutRowsParent;
+        [SerializeField] private Toggle layoutLockToggle;
+        [SerializeField] private MaterialIcon layoutLockIcon;
         private readonly List<PanelLayoutRow> rows = new List<PanelLayoutRow>();
         private Dictionary<string, byte[]> customLayouts = new Dictionary<string, byte[]>();
         private byte[] defaultLayoutData;
@@ -89,6 +93,11 @@ namespace ArcCreate.Compose.Components
                 rows.Add(newRow);
                 newRow.SetData(this, pair.Value, pair.Key);
             }
+            
+            Application.quitting += SaveLayoutLockState;
+            layoutLockToggle.onValueChanged.AddListener(ToggleLock);
+            layoutLockToggle.isOn = LoadLayoutLockState();
+            PanelNotificationCenter.OnStartedDraggingTab += OnTabDragStarted;
         }
 
         private void OnDestroy()
@@ -99,6 +108,26 @@ namespace ArcCreate.Compose.Components
             Application.quitting -= SaveLayoutForNextSession;
             SaveLayoutForNextSession();
             SaveCustomLayouts(customLayouts);
+            
+            layoutLockToggle.onValueChanged.RemoveListener(ToggleLock);
+            PanelNotificationCenter.OnStartedDraggingTab -= OnTabDragStarted;
+            Application.quitting -= SaveLayoutLockState;
+            SaveLayoutLockState();
+        }
+
+        private void ToggleLock(bool isOn)
+        {
+            layoutLockIcon.iconUnicode = isOn ? "e899" : "e898";
+            layoutLockIcon.color = isOn ? Color.white : new Color(0.75f, 0.75f, 0.75f, 1f);
+        }
+
+        private void OnTabDragStarted(PanelTab tab)
+        {
+            if (tab == null || tab.Panel == null) return;
+            if (layoutLockToggle.isOn)
+            {
+                PanelManager.Instance.CancelDraggingPanel();
+            }
         }
 
         private void TogglePicker()
@@ -161,6 +190,13 @@ namespace ArcCreate.Compose.Components
 
             var serialized = JsonConvert.SerializeObject(stringConverted);
             PlayerPrefs.SetString(PlayerPrefKey, serialized);
+        }
+        
+        private bool LoadLayoutLockState() => Convert.ToBoolean(PlayerPrefs.GetInt(PlayerPrefLayoutLockKey));
+
+        private void SaveLayoutLockState()
+        {
+            PlayerPrefs.SetInt(PlayerPrefLayoutLockKey, layoutLockToggle.isOn ? 1 : 0);
         }
     }
 }


### PR DESCRIPTION
implement the suggestion [`Setting to lock editor layout`](https://discord.com/channels/1083452023250354206/1269642953903837215)

---

<img width="874" height="64" alt="image" src="https://github.com/user-attachments/assets/f1a127c9-ae22-4859-98a0-ef662bc8c9ef" />

- add a lock toggle in topbar
- the lock state is saved when application exits
- when locked, tabs are not movable, but you can still resize panels

preview video: https://discord.com/channels/1083452023250354206/1269642953903837215/1476543831477587978

# Scene Modification

## Compose

<img width="2560" height="2048" alt="image" src="https://github.com/user-attachments/assets/a7ed3213-89d0-47ad-9687-7046eeab0462" />
<img width="2560" height="2048" alt="image" src="https://github.com/user-attachments/assets/81f09273-6934-4031-ac68-ff2322c038f9" />
<img width="2560" height="2048" alt="image" src="https://github.com/user-attachments/assets/0ae5628a-de48-4516-bacc-670fdbc53987" />
<img width="2560" height="2048" alt="image" src="https://github.com/user-attachments/assets/d63a9602-3e4b-4334-8dad-cfcfb51b9ee4" />

