### PR TITLE
align sfx with song when hitsounds are muted

### DIFF
--- a/Assets/Scripts/Gameplay/Audio/AudioService.cs
+++ b/Assets/Scripts/Gameplay/Audio/AudioService.cs
@@ -139,9 +139,9 @@ namespace ArcCreate.Gameplay.Audio
 
         public Dictionary<string, AudioClip> SfxAudioClips => Services.Hitsound.SfxAudioClips;
 
-        private int FullOffset => Values.ChartAudioOffset + Mathf.RoundToInt(Settings.GlobalAudioOffset.Value * playbackSpeed);
+        public int FullOffset => Values.ChartAudioOffset + Mathf.RoundToInt(Settings.GlobalAudioOffset.Value * playbackSpeed);
 
-        private int GlobalOffset => Mathf.RoundToInt(Settings.GlobalAudioOffset.Value * playbackSpeed);
+        public int GlobalOffset => Mathf.RoundToInt(Settings.GlobalAudioOffset.Value * playbackSpeed);
 
         public void SetAudioTimingSilent(int timing)
         {

--- a/Assets/Scripts/Gameplay/Data/Events/ArcTap.cs
+++ b/Assets/Scripts/Gameplay/Data/Events/ArcTap.cs
@@ -11,7 +11,6 @@ namespace ArcCreate.Gameplay.Data
         private bool judgementRequestSent = false;
         private bool isHit = false;
         private bool isSfx;
-        private bool sfxPlayed = false;
         private Texture texture;
 
         public HashSet<Tap> ConnectedTaps { get; } = new HashSet<Tap>();
@@ -25,6 +24,7 @@ namespace ArcCreate.Gameplay.Data
         public float WorldY => Arc.WorldYAt(Timing);
 
         public string Sfx => Arc.Sfx;
+        public bool SfxPlayed { get; private set; } = false;
 
         public override ArcEvent Clone()
         {
@@ -49,7 +49,7 @@ namespace ArcCreate.Gameplay.Data
         {
             judgementRequestSent = timing > Timing;
             isHit = timing > Timing;
-            sfxPlayed = timing > Timing;
+            SfxPlayed = timing > Timing - Services.Audio.FullOffset;
         }
 
         public void Rebuild()
@@ -94,12 +94,12 @@ namespace ArcCreate.Gameplay.Data
                 RequestJudgement(groupProperties);
                 judgementRequestSent = true;
             }
-
-            if (currentTiming >= Timing && !sfxPlayed)
-            {
-                Services.Hitsound.PlayArcTapHitsound(Timing, Sfx, isFromJudgement: false);
-                sfxPlayed = true;
-            }
+        }
+        
+        public void PlayMutedSfx()
+        {
+            Services.Hitsound.PlayArcTapHitsound(Timing, Sfx, isFromJudgement: false);
+            SfxPlayed = true;
         }
 
         public void UpdateRender(int currentTiming, double currentFloorPosition, GroupProperties groupProperties)

--- a/Assets/Scripts/Gameplay/GameplayManager.cs
+++ b/Assets/Scripts/Gameplay/GameplayManager.cs
@@ -149,7 +149,7 @@ namespace ArcCreate.Gameplay
             Services.Camera.UpdateCamera(currentTiming);
             Services.Chart.UpdateChartRender(currentTiming);
             Services.Score.UpdateDisplay();
-            Services.Hitsound.UpdateHitsoundHistory(currentTiming);
+            Services.Hitsound.UpdateHitsounds(currentTiming);
             Services.Render.UpdateRenderers();
 
             gameplayData.NotifyUpdate(currentTiming);

--- a/Assets/Scripts/Gameplay/Hitsound/HitsoundService.cs
+++ b/Assets/Scripts/Gameplay/Hitsound/HitsoundService.cs
@@ -22,6 +22,7 @@ namespace ArcCreate.Gameplay.Hitsound
         private IHitsoundPlayer hitsoundPlayer;
 
         private readonly Dictionary<string, AudioClip> sfxClips = new Dictionary<string, AudioClip>();
+        private readonly Dictionary<string, List<ArcTap>> sfxTimings = new Dictionary<string, List<ArcTap>>();
         private readonly UnorderedList<int> playedTapHitsoundTimings = new UnorderedList<int>(30);
         private readonly UnorderedList<int> playedArcHitsoundTimings = new UnorderedList<int>(30);
 
@@ -88,6 +89,7 @@ namespace ArcCreate.Gameplay.Hitsound
             }
 
             sfxClips.Clear();
+            sfxTimings.Clear();
 
             List<UniTask> loadTasks = new List<UniTask>();
             HashSet<string> sfxs = new HashSet<string>();
@@ -97,7 +99,16 @@ namespace ArcCreate.Gameplay.Hitsound
             {
                 if (!string.IsNullOrEmpty(at.Sfx) && at.Sfx != "none")
                 {
-                    sfxs.Add(at.Sfx);
+                    string sfx = at.Sfx;
+                    sfxs.Add(sfx);
+                    if (sfxTimings.ContainsKey(sfx))
+                    {
+                        sfxTimings[sfx].Add(at);
+                    }
+                    else
+                    {
+                        sfxTimings.Add(sfx, new List<ArcTap>() { at });
+                    }
                 }
             }
 
@@ -125,7 +136,35 @@ namespace ArcCreate.Gameplay.Hitsound
             IsLoaded = true;
         }
 
-        public void UpdateHitsoundHistory(int currentTiming)
+        public void UpdateHitsounds(int currentTiming)
+        {
+            PlayMutedSfx(currentTiming);
+            UpdateHitsoundHistory(currentTiming);
+        }
+
+        private void PlayMutedSfx(int currentTiming)
+        {
+            if (IsMuted)
+            {
+                foreach (string sfx in sfxTimings.Keys)
+                {
+                    int noteIndex = 0;
+                    while (noteIndex < sfxTimings[sfx].Count)
+                    {
+                        ArcTap at = sfxTimings[sfx][noteIndex];
+                        
+                        int timing = at.Timing - Services.Audio.FullOffset;
+                        if (!at.SfxPlayed && currentTiming >= timing)
+                        {
+                            at.PlayMutedSfx();
+                        }
+                        noteIndex++;
+                    }
+                }
+            }
+        }
+
+        private void UpdateHitsoundHistory(int currentTiming)
         {
             PurgeOldSoundPlayedTimings(currentTiming, playedArcHitsoundTimings, Values.HoldMissLateJudgeWindow);
             PurgeOldSoundPlayedTimings(currentTiming, playedTapHitsoundTimings, Values.HoldMissLateJudgeWindow);

--- a/Assets/Scripts/Gameplay/Hitsound/IHitsoundService.cs
+++ b/Assets/Scripts/Gameplay/Hitsound/IHitsoundService.cs
@@ -58,7 +58,7 @@ namespace ArcCreate.Gameplay.Hitsound
         /// <returns>Unitask instance.</returns>
         UniTask LoadCustomSfxs(string parentFolder, IFileAccessWrapper fileAccess);
 
-        void UpdateHitsoundHistory(int currentTiming);
+        void UpdateHitsounds(int currentTiming);
 
         void ResetHitsoundHistory();
     }

--- a/Assets/Scripts/Gameplay/IAudioControl.cs
+++ b/Assets/Scripts/Gameplay/IAudioControl.cs
@@ -7,6 +7,10 @@ namespace ArcCreate.Gameplay
 {
     public interface IAudioControl
     {
+        int FullOffset { get; }
+        
+        int GlobalOffset { get; }
+        
         /// <summary>
         /// Gets or sets the audio's actual timing.
         /// Setting this value will cause score to reset to 0.


### PR DESCRIPTION
fixes an issue with arctap sfx being aligned with note timing instead of the song when hitsounds are muted